### PR TITLE
Bump `vimeo/psalm` from `6.12.0` to `6.12.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "mockery/mockery": "~1.6.12",
         "phpunit/phpunit": "~12.2.6",
         "symfony/var-dumper": "~7.3.1",
-        "vimeo/psalm": "~6.12.0"
+        "vimeo/psalm": "~6.12.1"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2dd34f44b07a2e7ad9dbce6661b33d06",
+    "content-hash": "9edd67db5823e7db27dd0652f57557d2",
     "packages": [],
     "packages-dev": [
         {
@@ -7310,16 +7310,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.12.0",
+            "version": "6.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2"
+                "reference": "e71404b0465be25cf7f8a631b298c01c5ddd864f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/cf420941d061a57050b6c468ef2c778faf40aee2",
-                "reference": "cf420941d061a57050b6c468ef2c778faf40aee2",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e71404b0465be25cf7f8a631b298c01c5ddd864f",
+                "reference": "e71404b0465be25cf7f8a631b298c01c5ddd864f",
                 "shasum": ""
             },
             "require": {
@@ -7424,7 +7424,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-05-28T12:52:06+00:00"
+            "time": "2025-07-04T09:56:28+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
Bumps `vimeo/psalm` from `6.12.0` to `6.12.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`