### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf86bcfcaa3a27463c92b12704154f09",
+    "content-hash": "c4aefbddb7519dab37a241279b30f823",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main`.

This pull request changes the following file(s): 

- Update `composer.lock`