### PR TITLE
Update ghostwriter/coding-standard to version dev-main#4c9bc3e

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,9 +41,9 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^12.3.12",
-        "symfony/var-dumper": "^7.3.3"
+        "mockery/mockery": "~1.6.12",
+        "phpunit/phpunit": "~12.3.12",
+        "symfony/var-dumper": "~7.3.3"
     },
     "prefer-stable": true,
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a537d58cc3165942604421d61fba2372",
+    "content-hash": "3953574946b5e3e86d1603326714511c",
     "packages": [],
     "packages-dev": [
         {
@@ -766,12 +766,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "5a3b19053dc74511910d5f81bb41e8422c6842c8"
+                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/5a3b19053dc74511910d5f81bb41e8422c6842c8",
-                "reference": "5a3b19053dc74511910d5f81bb41e8422c6842c8",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/4c9bc3e55140d0c376a3a68f561f7164699e8225",
+                "reference": "4c9bc3e55140d0c376a3a68f561f7164699e8225",
                 "shasum": ""
             },
             "require": {
@@ -821,7 +821,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "~1.6.12",
                 "nikic/php-parser": "~5.6.1",
-                "phpunit/phpunit": "~12.3.11",
+                "phpunit/phpunit": "~12.3.12",
                 "symfony/var-dumper": "~7.3.3"
             },
             "default-branch": true,
@@ -928,7 +928,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-19T12:54:01+00:00"
+            "time": "2025-09-21T13:20:26+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#5a3b190` to `dev-main#4c9bc3e`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`