### PR TITLE
Update ghostwriter/coding-standard to version dev-main#e7637cc

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -638,12 +638,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "776cfbdf9f48c7cff70ef4dc836d06de24266e99"
+                "reference": "e7637ccacee78338bec3a474822553939a47c5f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/776cfbdf9f48c7cff70ef4dc836d06de24266e99",
-                "reference": "776cfbdf9f48c7cff70ef4dc836d06de24266e99",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/e7637ccacee78338bec3a474822553939a47c5f9",
+                "reference": "e7637ccacee78338bec3a474822553939a47c5f9",
                 "shasum": ""
             },
             "require": {
@@ -689,6 +689,7 @@
                 "ext-sodium": "*",
                 "ext-sqlite3": "*",
                 "ext-tokenizer": "*",
+                "ext-xdebug": "*",
                 "ext-xml": "*",
                 "ext-xmlreader": "*",
                 "ext-xmlwriter": "*",
@@ -697,19 +698,17 @@
                 "ext-zend-opcache": "*",
                 "ext-zip": "*",
                 "ext-zlib": "*",
+                "ghostwriter/config": "^2.0.1",
                 "ghostwriter/console": "^0.1.2",
+                "mockery/mockery": "^1.6.12",
+                "nikic/php-parser": "^5.6.2",
                 "php": "~8.4.0 || ~8.5.0",
-                "symfony/process": "^8.0.0"
+                "phpunit/phpunit": "^12.4.4",
+                "symfony/process": "^8.0.0",
+                "symfony/var-dumper": "^8.0.0"
             },
             "conflict": {
                 "pestphp/pest": "*"
-            },
-            "require-dev": {
-                "ext-xdebug": "*",
-                "mockery/mockery": "^1.6.12",
-                "nikic/php-parser": "^5.6.2",
-                "phpunit/phpunit": "^12.4.4",
-                "symfony/var-dumper": "^8.0.0"
             },
             "default-branch": true,
             "bin": [
@@ -820,7 +819,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-28T01:32:02+00:00"
+            "time": "2025-11-28T23:37:10+00:00"
         },
         {
             "name": "ghostwriter/config",
@@ -1386,16 +1385,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.1",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
-                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
                 "shasum": ""
             },
             "require": {
@@ -1438,9 +1437,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
             },
-            "time": "2025-08-13T20:13:15+00:00"
+            "time": "2025-10-21T19:32:17+00:00"
         },
         {
             "name": "phar-io/manifest",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#776cfbd` to `dev-main#e7637cc`.

This pull request changes the following file(s): 

- Update `composer.lock`