### PR TITLE
Update boundwize/structarmed to version 0.6.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.8",
+        "boundwize/structarmed": "^0.6.9",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf8c5e9de952ffdecb98377dc010fb5c",
+    "content-hash": "6d4de264ea2c70a935822ef1d6d25ee8",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.8",
+            "version": "0.6.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "e37f44fc1f61c2c96837eafcec90ed88a3c2d84b"
+                "reference": "3c2f00553b55c98de1966d75d914ea27a35bcf7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/e37f44fc1f61c2c96837eafcec90ed88a3c2d84b",
-                "reference": "e37f44fc1f61c2c96837eafcec90ed88a3c2d84b",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/3c2f00553b55c98de1966d75d914ea27a35bcf7a",
+                "reference": "3c2f00553b55c98de1966d75d914ea27a35bcf7a",
                 "shasum": ""
             },
             "require": {
@@ -67,7 +67,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.8"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.9"
             },
             "funding": [
                 {
@@ -75,7 +75,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-18T16:40:17+00:00"
+            "time": "2026-05-19T08:16:03+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -144,16 +144,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "86f89b0de4e00bc7b20570b22f3e6467ea51b329"
+                "reference": "7cd775e1b9f3bcf6c31712bd6e7597123147a674"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/86f89b0de4e00bc7b20570b22f3e6467ea51b329",
-                "reference": "86f89b0de4e00bc7b20570b22f3e6467ea51b329",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/7cd775e1b9f3bcf6c31712bd6e7597123147a674",
+                "reference": "7cd775e1b9f3bcf6c31712bd6e7597123147a674",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.6.8",
+                "boundwize/structarmed": "^0.6.9",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -264,7 +264,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-18T19:59:50+00:00"
+            "time": "2026-05-19T08:49:35+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.8` to `0.6.9`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`